### PR TITLE
PoC Using helm for kuadrant deployment

### DIFF
--- a/kuadrant/Chart.yaml
+++ b/kuadrant/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: kuadrant
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: "1.0"

--- a/kuadrant/crds/kuadrant.yaml
+++ b/kuadrant/crds/kuadrant.yaml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kuadrants.kuadrant.io
+spec:
+  conversion:
+    strategy: None
+  group: kuadrant.io
+  names:
+    kind: Kuadrant
+    listKind: KuadrantList
+    plural: kuadrants
+    singular: kuadrant
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Kuadrant configures installations of Kuadrant Service Protection
+          components
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KuadrantSpec defines the desired state of Kuadrant
+            properties: {}
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/kuadrant/templates/catalogsource.yaml
+++ b/kuadrant/templates/catalogsource.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: kuadrant-operator-catalog
+  namespace: {{ .Values.kuadrant.namespace }}
+spec:
+  sourceType: grpc
+  image: {{ .Values.kuadrant.indexImage }}
+  displayName: Kuadrant Operators
+  publisher: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 45m

--- a/kuadrant/templates/kuadrant-install.yaml
+++ b/kuadrant/templates/kuadrant-install.yaml
@@ -1,0 +1,14 @@
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: kuadrant
+  namespace: {{ .Values.kuadrant.namespace }}
+spec:
+  limitador:
+    storage:
+      redis-cached:
+        configSecretRef:
+          name: redis-config 

--- a/kuadrant/templates/kuadrant.yaml
+++ b/kuadrant/templates/kuadrant.yaml
@@ -1,0 +1,21 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: kuadrant-operator
+  namespace: {{ .Values.kuadrant.namespace }}
+spec:
+  channel: {{ .Values.kuadrant.channel }}
+  installPlanApproval: Automatic
+  name: kuadrant-operator
+  source: kuadrant-operator-catalog
+  sourceNamespace: {{ .Values.kuadrant.namespace }}
+---
+kind: OperatorGroup
+apiVersion: operators.coreos.com/v1
+metadata:
+  name: kuadrant
+  namespace: {{ .Values.kuadrant.namespace }}
+spec: 
+  upgradeStrategy: Default

--- a/kuadrant/templates/label-job.yaml
+++ b/kuadrant/templates/label-job.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  name: metrics-configure-labels
+  namespace: {{ .Values.kuadrant.namespace }}
+spec:
+  template:
+    spec:
+      containers: 
+        - image: quay.io/kuadrant/observability-configure:latest
+          command: ["metrics.sh"]
+          name: "configure"
+      restartPolicy: OnFailure 
+  backoffLimit: 15   

--- a/kuadrant/templates/ns.yaml
+++ b/kuadrant/templates/ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: {{ .Values.kuadrant.namespace }}

--- a/kuadrant/templates/rolebinding.yaml
+++ b/kuadrant/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  creationTimestamp: null
+  name: job-role-binding
+  namespace: {{ .Values.kuadrant.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: job-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Values.kuadrant.namespace }}

--- a/kuadrant/templates/servicemonitors.yaml
+++ b/kuadrant/templates/servicemonitors.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: authorino
+  namespace: {{ .Values.kuadrant.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"  
+spec:
+  endpoints:
+    - port: http
+  selector:
+    matchLabels:
+      app: authorino
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: limitador
+  namespace: {{ .Values.kuadrant.namespace }}
+spec:
+  endpoints:
+    - port: http
+  selector:
+    matchLabels:
+      app: limitador

--- a/kuadrant/values.yaml
+++ b/kuadrant/values.yaml
@@ -1,0 +1,4 @@
+kuadrant:
+  namespace: kuadrant-system
+  indexImage: 'quay.io/kuadrant/kuadrant-operator-catalog:v0.7.0'
+  channel: stable


### PR DESCRIPTION
I managed to force helm (using a small cheat) to create CRs of unknown type by providing dummy CRD (kuadrant). 
Kuadrant objects gets created with all spec fields, OLM then tries to install "proper" CRD . This mechanism enables having operator and operands installation in a single chart. However Kuadrant object is not checked against any OpenAPI specification during its creation and the only mechanism that prevents mistakes in object's definition is refusal of application of new CRD via InstallPlan.


